### PR TITLE
address CRAN archiving

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rflexscan
 Type: Package
 Title: The Flexible Spatial Scan Statistic
 Version: 1.2.0
-Date: 2023-03-04
+Date: 2025-04-01
 Author: Takahiro Otani,
     Kunihiko Takahashi
 Maintainer: Takahiro Otani <otani@med.nagoya-cu.ac.jp>
@@ -20,5 +20,5 @@ Suggests: knitr,
     rmarkdown,
     spdep,
     spData
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,6 @@ LinkingTo: Rcpp
 Suggests: knitr,
     rmarkdown,
     spdep,
-    spData
+    spData (>= 2.3.1)
 RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/R/flexscan.R
+++ b/R/flexscan.R
@@ -682,7 +682,7 @@ plot.rflexscan <- function(x,
 #' library(sf)
 #' library(spdep)
 #' data("nc.sids")
-#' sids.shp <- read_sf(system.file("shapes/sids.shp", package="spData")[1])
+#' sids.shp <- st_read(system.file("shapes/sids.gpkg", package="spData")[1], quiet=TRUE)
 #' 
 #' # calculate the expected numbers of cases
 #' expected <- nc.sids$BIR74 * sum(nc.sids$SID74) / sum(nc.sids$BIR74)

--- a/man/choropleth.Rd
+++ b/man/choropleth.Rd
@@ -43,7 +43,7 @@ larger than the number of colors in the palette are not highlighted.
 library(sf)
 library(spdep)
 data("nc.sids")
-sids.shp <- read_sf(system.file("shapes/sids.shp", package="spData")[1])
+sids.shp <- st_read(system.file("shapes/sids.gpkg", package="spData")[1], quiet=TRUE)
 
 # calculate the expected numbers of cases
 expected <- nc.sids$BIR74 * sum(nc.sids$SID74) / sum(nc.sids$BIR74)


### PR DESCRIPTION
See https://github.com/cran-task-views/Spatial/issues/88 and https://www.stats.ox.ac.uk/pub/bdr/donttest/rflexscan.out. The problem was that `sids.shp` was read from `spData`, but all ESRI Shapefiles were made defunct in that package from version 2.3.4, see https://github.com/Nowosad/spData/issues/62. As your use was hidden by donttest, our checks of spData did not catch your case, but had you implemented GA CI with --as-cran for example, you would have found this.

With these changes, the package passes R CMD check --as-cran with R 4.4.3 for me, please check on forthcoming R 4.5.0 and devel.

If you do not update and submit the package, it will have to be dropped from the task view.